### PR TITLE
Upgrade to Scala 2.12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Please see the `Test.scala` file for an example of loading.
 
 <table>
   <tr>
+    <td>0.12</td>
+    <td>2018-04-12</td>
+    <td>Upgrade to Scala 2.12.x</td>
+    <td>Change test framework to org.scalatest</td>
+    <td></td>
+  <tr>
+  <tr>
     <td>0.11</td>
     <td>2016-04-29</td>
     <td>Changed organisation</td>

--- a/build.sbt
+++ b/build.sbt
@@ -6,18 +6,17 @@ name := "scala-pdf"
 
 organization := "net.kaliber"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.4"
 
 crossScalaVersions := Seq("2.10.4", "2.11.4", scalaVersion.value)
 
 libraryDependencies ++= Seq(
-  "org.xhtmlrenderer" % "flying-saucer-core" % "9.0.7",
-  "org.xhtmlrenderer" % "flying-saucer-pdf" % "9.0.7",
+  "org.xhtmlrenderer" % "flying-saucer-core" % "9.0.8",
+  "org.xhtmlrenderer" % "flying-saucer-pdf" % "9.0.8",
   "net.sf.jtidy" % "jtidy" % "r938",
-  "org.qirx" %% "little-spec" % "0.4" % "test"
+  "org.scalactic" %% "scalactic" % "3.0.5",
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
-
-testFrameworks += new TestFramework("org.qirx.littlespec.sbt.TestFramework")
 
 resolvers ++= Seq(
   "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"

--- a/src/test/scala/Test.scala
+++ b/src/test/scala/Test.scala
@@ -2,12 +2,12 @@ import java.net.URLClassLoader
 import java.nio.file.{Files, Path, Paths}
 
 import net.kaliber.pdf.PdfRenderer
-import org.qirx.littlespec.Specification
+import org.scalatest._
 import org.xhtmlrenderer.pdf.ITextRenderer
 
 import scala.io.Source
 
-object Test extends Specification {
+class Test extends FlatSpec with Matchers {
 
   val examples: Path = Paths.get("./example")
   val `test.pdf`: Path = examples resolve "test.pdf"
@@ -22,7 +22,7 @@ object Test extends Specification {
     |A CUSTOM FONT.
     |
     |${`test.pdf`}
-    |============================""".stripMargin - {
+    |============================""".stripMargin should s"produce file ${`test.pdf`}" in {
      val classLoader = new URLClassLoader(Array(examples.toUri.toURL))
 
      val body = {
@@ -37,7 +37,8 @@ object Test extends Specification {
 
      Files write (`test.pdf`, pdf)
 
-     todo
+     val fileExist = Files.isRegularFile(`test.pdf`) & Files.isReadable(`test.pdf`)
+     fileExist === (true)
 
     // Todo Write proper tests please
 


### PR DESCRIPTION
Minimal changes require test framework change. 
Using actively used and maintained org.scalatest.

Keep flying-saucer 9.0.x, moving to 9.1.x requires
more work.